### PR TITLE
Fix variable name

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Include Ad-hoc
   include: ad-hocs/main.yml
-  when: consul_adhoc_build_raft_peers is defined and consul_adhoc_build_raft_peers or consul_adhoc_clear-data-dir is defined and consul_adhoc_clear-data-dir
+  when: consul_adhoc_build_raft_peers is defined and consul_adhoc_build_raft_peers or consul_adhoc_clear_data_dir is defined and consul_adhoc_clear_data_dir
 
 - name: Include Packages
   include: install/packages.yml


### PR DESCRIPTION
# What this PR changes:
This PR fixes following issue, wrongly considered as an Ansible bug:
`TASK [consul : adhoc | rebuild peers | Group by consul server] *****************
fatal: [concourse-meal-plan-worker005.tools.hellofresh.io]: FAILED! => {"failed": true, "msg": "The conditional check 'consul_adhoc_build_raft_peers is defined and consul_adhoc_build_raft_peers or consul_adhoc_clear-data-dir is defined and consul_adhoc_clear-data-dir' failed. The error was: error while evaluating conditional (consul_adhoc_build_raft_peers is defined and consul_adhoc_build_raft_peers or consul_adhoc_clear-data-dir is defined and consul_adhoc_clear-data-dir): 'consul_adhoc_clear' is undefined\n\nThe error appears to have been in '/automation/roles/external/consul/tasks/ad-hocs/build-raft-peers.yml': line 3, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: adhoc | rebuild peers | Group by consul server\n  ^ here\n"}`
