### PR TITLE
Backends now use service_name (without environment_name) by default

### DIFF
--- a/templates/haproxy.ctmp.j2
+++ b/templates/haproxy.ctmp.j2
@@ -66,11 +66,11 @@ listen stats
 {% set tags_contains = consumer_service.tags_contains | default(false) %}
 {% set tag_regex = consumer_service.tag_regex | default(false) %}
 {% set haproxy_setting = consul_services[service_name].haproxy | default({}) %}
-# Service Config for {{ service_name  }}
-backend {{ consul_services[service_name].name }}
+# Service Config for {{ service_name }}
+backend {{ service_name }}-{{ env_name }}
     mode {{ haproxy_setting.service_mode | default('http') }}
-
-    <% range service "{{ consul_services[service_name].name }}{{ consul_template_service_options_str }}" %>
+    <% scratch.Set "serviceFound" "False" -%>
+    <% range service "{{ service_name }}{{ consul_template_service_options_str }}" %>
     <% scratch.Set "weightValue" "100" -%>
     <% range .Tags -%>
     <% if . | contains "WEIGHT:" -%>
@@ -80,6 +80,7 @@ backend {{ consul_services[service_name].name }}
     <% end -%><% end -%>
 
     <% if .Tags | contains "env:{{ env_name }}" -%> # Match envrionment tag
+    <% scratch.Set "serviceFound" "True" -%>
 {% if tags_contains %}<%if .Tags | contains "{{ tags_contains}}"%> # Match tags_contains {{ tags_contains }}{% endif %}
 
 {% if tag_regex %}<%if .Tags | join " "  | regexMatch "{{ tag_regex }}"%> # Match tag_regex {{ tag_regex }}{% endif %}
@@ -89,11 +90,34 @@ backend {{ consul_services[service_name].name }}
 {% if tags_contains %}<%else%> # Did not match tags_contains {{ tags_contains }}<%end%>{% endif %}
     <%end%>
     <% end -%>
+    <% $serviceFound := scratch.Get "serviceFound" -%>
+    <% if eq $serviceFound "False" -%>
+    <% range service "{{ service_name }}-{{ env_name }}{{ consul_template_service_options_str }}" %>
+    <% scratch.Set "weightValue" "100" -%>
+    <% range .Tags -%>
+    <% if . | contains "WEIGHT:" -%>
+    <% $weightValue := . | split ":" -%>
+    <% $weightValue := index $weightValue 1 -%>
+    <% scratch.Set "weightValue" $weightValue -%>
+    <% end -%><% end -%>
 
-frontend {{ consul_services[service_name].name }}
+    <% if .Tags | contains "env:{{ env_name }}" -%> # Match envrionment tag
+    <% scratch.Set "serviceFound" "True" -%>
+{% if tags_contains %}<%if .Tags | contains "{{ tags_contains}}"%> # Match tags_contains {{ tags_contains }}{% endif %}
+
+{% if tag_regex %}<%if .Tags | join " "  | regexMatch "{{ tag_regex }}"%> # Match tag_regex {{ tag_regex }}{% endif %}
+
+    server <%.ID%>_<%.Address%>:<%.Port%> <%.Address%>:<%.Port%> {% if consul_haproxy_default_balance == 'roundrobin' %}weight <% scratch.Get "weightValue" %> {% endif %} {{ haproxy_setting.server_options | default(consul_haproxy_default_server_options) }}
+{% if tag_regex %}<%else%> # Did not match tag_regex {{ tag_regex }}<%end%>{% endif %}
+{% if tags_contains %}<%else%> # Did not match tags_contains {{ tags_contains }}<%end%>{% endif %}
+    <%end%>
+   <% end -%>
+   <% end -%>
+
+frontend {{ service_name }}-{{ env_name }}
     mode {{ haproxy_setting.service_mode | default('http') }}
     bind localhost:{{ consul_services[service_name].local_port | default(consul_services[service_name].port) }}
-    default_backend {{ consul_services[service_name].name }}
+    default_backend {{ service_name }}-{{ env_name }}
 
 {% endfor %}
 {% endif %}

--- a/test/integration/basic-agent/agent_vars.yml
+++ b/test/integration/basic-agent/agent_vars.yml
@@ -23,7 +23,7 @@ consul_services             :
       service_mode          : "http"
   # A local service superssh that uses localport
   superssh                  :
-    name                    : "superssh-different-name"
+    name                    : "superssh-testing"
     tags                    :
                               - "test"
                               - "env:testing"

--- a/test/integration/basic-agent/serverspec/consul_service_spec.rb
+++ b/test/integration/basic-agent/serverspec/consul_service_spec.rb
@@ -2,9 +2,9 @@ require_relative '../../helper_spec.rb'
 
 describe 'superssh service (localport option)' do
   describe 'definition by name' do
-    describe command 'curl -s -v http://127.0.0.1:8500/v1/catalog/service/superssh-different-name' do
+    describe command 'curl -s -v http://127.0.0.1:8500/v1/catalog/service/superssh-testing' do
       its(:exit_status) { should eq 0 }
-      its(:stdout) { should contain '"ServiceName":"superssh-different-name"' }
+      its(:stdout) { should contain '"ServiceName":"superssh-testing"' }
       its(:stdout) { should match /"ServiceTags":\[.*"env:testing".*/ }
       its(:stdout) { should match /"ServiceTags":\[.*"WEIGHT:77".*/ }
       its(:stdout) { should match /"ServiceTags":\[.*"test".*/ }
@@ -13,9 +13,9 @@ describe 'superssh service (localport option)' do
   end
 
   describe 'health is passing' do
-    describe command 'curl -s -v http://127.0.0.1:8500/v1/health/service/superssh-different-name' do
+    describe command 'curl -s -v http://127.0.0.1:8500/v1/health/service/superssh-testing' do
       its(:exit_status) { should eq 0 }
-      its(:stdout) { should contain '"Service":"superssh-different-name"' }
+      its(:stdout) { should contain '"Service":"superssh-testing"' }
       its(:stdout) { should contain '"Status":"passing"' }
     end
   end
@@ -114,19 +114,19 @@ describe 'hellofresh service (normal port option)' do
 
   describe 'HAProxy server backend should be listed and up' do
     let(:pre_command) { 'sleep 2' }
-    describe command "echo 'show stat' | socat unix-connect:/var/lib/haproxy/stats.sock stdio | grep hellofresh,hellofresh | grep UP" do
+    describe command "echo 'show stat' | socat unix-connect:/var/lib/haproxy/stats.sock stdio | grep hellofresh-testing,hellofresh | grep UP" do
       its(:exit_status) { should eq 0 }
     end
   end
 
   describe 'hellofresh backend should have default weight' do
-    describe command 'echo "get weight hellofresh/`cat /etc/haproxy/haproxy.cfg  | grep "server hellofresh" | awk \'{print $2}\'`" | socat unix-connect:/var/lib/haproxy/stats.sock stdio  | grep 100' do
+    describe command 'echo "get weight hellofresh-testing/`cat /etc/haproxy/haproxy.cfg  | grep "server hellofresh" | awk \'{print $2}\'`" | socat unix-connect:/var/lib/haproxy/stats.sock stdio  | grep 100' do
       its(:stdout) { should contain '100 \(initial 100\)'}
     end
   end
 
-  describe 'superssh-different-name backend should have set weight' do
-    describe command 'echo "get weight superssh-different-name/`cat /etc/haproxy/haproxy.cfg  | grep "server superssh-different-name" | awk \'{print $2}\'`" | socat unix-connect:/var/lib/haproxy/stats.sock stdio  | grep 77' do
+  describe 'superssh-testing backend should have set weight' do
+    describe command 'echo "get weight superssh-testing/`cat /etc/haproxy/haproxy.cfg  | grep "server superssh-testing" | awk \'{print $2}\'`" | socat unix-connect:/var/lib/haproxy/stats.sock stdio  | grep 77' do
       its(:stdout) { should contain '77 \(initial 77\)'}
     end
   end


### PR DESCRIPTION
Still fallsback to <service_name>-<env_name> if no service is found.
This fallback functionality will be removed once all services are migrated to the new version of the role.

Signed-off-by: Ali Rizwan <ari@hellofresh.com> 